### PR TITLE
Link to proposal in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,6 +9,8 @@ Further conversation on this work is discussed on the [WebId profile gitter chat
 ## This Type Indexes spec is:
 ...first and foremost, trying to simply document what-is. This means, we are documenting how type indexes are implemented and used NOW.
 
+Whilst this is in being worked on, you can refer to the [initial proposal](https://github.com/solid/solid/blob/main/proposals/data-discovery.md#type-index-registry) to learn about the current status.
+
 ## Future Type Index versions:
 ...might build on top of this spec. We staretd collecting ideas on a dedicated [git ticket](https://github.com/solid/type-indexes/issues/1). If you want to start discussion on one of those ideas, feel free. In order to have them considered for future iterations of this document please label the ticket with `discussion` and `future iteration` please.
 


### PR DESCRIPTION
I just realized I've been linking to this repository when I mention type indexes anywhere, but if a developer were to open it they wouldn't learn anything about type indexes at the moment. Until this is more fleshed out, I think we should keep a link to the previous proposal so that this repository is helpful in some way.

Maybe it could be phrased in a different way though, I'm open to suggestions :).