### PR TITLE
Remove mention of Solid Process from SotD

### DIFF
--- a/index.html
+++ b/index.html
@@ -1460,8 +1460,8 @@
                         rel="cito:citesAsAuthority"
                         ><cite>Solid Protocol</cite></a
                       >. Sarven Capadisli; Tim Berners-Lee; Ruben Verborgh;
-                      Kjetil Kjernsmo. W3C Solid Community Group. 17 December
-                      2021. Version 1.0.0. URL:
+                      Kjetil Kjernsmo. W3C Solid Community Group. 31 December
+                      2022. Version 0.10.0 URL:
                       <a href="https://solidproject.org/TR/protocol"
                         >https://solidproject.org/TR/protocol</a
                       >

--- a/index.html
+++ b/index.html
@@ -654,11 +654,8 @@
                 <a href="https://www.w3.org/community/solid/"
                   >Solid Community Group</a
                 >
-                as an <em>Editor’s Draft</em>. The sections that have been
-                incorporated have been reviewed following the
-                <a href="https://github.com/solid/process">Solid process</a>.
-                However, the information in this document is still subject to
-                change. You are invited to
+                as an <em>Editor’s Draft</em>. The information in this document
+                is still subject to change. You are invited to
                 <a href="https://github.com/solid/type-indexes/issues"
                   >contribute</a
                 >


### PR DESCRIPTION
PR updates the SotD section given that the [Solid CG Charter](https://www.w3.org/community/solid/charter/) supersedes Solid Process.